### PR TITLE
Enable the stencil for framebuffers + 50 lines of nightmares

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ TinyVG tries to be simpler. Fewer features, but powerful enough to cover 90% of 
 
 # Convert SVG into TVG
 
-Convert your SVG into a TVG her: https://svgtotvg.herokuapp.com/
+Convert your SVG into a TVG here: https://svgtotvg.herokuapp.com/
 
 Some things are not supported.
 

--- a/src/main/java/dev/lyze/gdxtinyvg/TinyVGIO.java
+++ b/src/main/java/dev/lyze/gdxtinyvg/TinyVGIO.java
@@ -59,8 +59,8 @@ public class TinyVGIO {
      * texture size. Each pass requires twice the width and height of the last!
      */
     @SuppressWarnings("GDXJavaFlushInsideLoop")
-    public static TextureRegion toTextureRegion(TinyVG tvg, TinyVGShapeDrawer drawer, int superSamplingPasses) {
-        if (superSamplingPasses < 1)
+    public static TextureRegion toTextureRegion(TinyVG tvg, TinyVGShapeDrawer drawer, int supersamplingPasses) {
+        if (supersamplingPasses < 1)
             return toTextureRegion(tvg, drawer);
 
         var batch = drawer.getBatch();
@@ -72,10 +72,10 @@ public class TinyVGIO {
         float initialScaleY = tvg.getScaleY();
         Texture resizedTexture = null;
 
-        for (int i = 0; i < superSamplingPasses; i++) {
+        for (int i = 0; i < supersamplingPasses; i++) {
             Texture bigTexture;
             if (resizedTexture == null) {
-                var scaleAmount = (float) Math.pow(2, superSamplingPasses);
+                var scaleAmount = (float) Math.pow(2, supersamplingPasses);
                 tvg.setScale(initialScaleX * scaleAmount, initialScaleY * scaleAmount);
                 bigTexture = toTextureRegion(tvg, drawer).getTexture();
             } else {
@@ -103,7 +103,7 @@ public class TinyVGIO {
             batch.begin();
 
         var resizedRegion = new TextureRegion(resizedTexture);
-        resizedRegion.flip(false, superSamplingPasses % 2 == 0);
+        resizedRegion.flip(false, supersamplingPasses % 2 == 0);
         return resizedRegion;
     }
 }

--- a/src/main/java/dev/lyze/gdxtinyvg/TinyVGIO.java
+++ b/src/main/java/dev/lyze/gdxtinyvg/TinyVGIO.java
@@ -25,7 +25,7 @@ public class TinyVGIO {
         int fboWidth = MathUtils.roundPositive(Math.abs(tvg.getWidth()));
         int fboHeight = MathUtils.roundPositive(Math.abs(tvg.getHeight()));
 
-        var fbo = new FrameBuffer(Pixmap.Format.RGBA8888, fboWidth, fboHeight, false);
+        var fbo = new FrameBuffer(Pixmap.Format.RGBA8888, fboWidth, fboHeight, false, true);
         var viewport = new FitViewport(tvg.getWidth(), tvg.getHeight());
         viewport.update(fboWidth, fboHeight, true);
 
@@ -84,7 +84,7 @@ public class TinyVGIO {
             int width = bigTexture.getWidth();
             int height = bigTexture.getHeight();
 
-            var fbo = new FrameBuffer(Pixmap.Format.RGBA8888, width / 2, height / 2, false, resizedTexture == null);
+            var fbo = new FrameBuffer(Pixmap.Format.RGBA8888, width / 2, height / 2, false);
             var viewport = new FitViewport(fbo.getWidth(), fbo.getHeight());
             viewport.update(fbo.getWidth(), fbo.getHeight(), true);
             batch.setProjectionMatrix(viewport.getCamera().combined);

--- a/src/main/java/dev/lyze/gdxtinyvg/TinyVGIO.java
+++ b/src/main/java/dev/lyze/gdxtinyvg/TinyVGIO.java
@@ -25,7 +25,7 @@ public class TinyVGIO {
         int fboWidth = MathUtils.roundPositive(Math.abs(tvg.getWidth()));
         int fboHeight = MathUtils.roundPositive(Math.abs(tvg.getHeight()));
 
-        var fbo = new FrameBuffer(Pixmap.Format.RGBA8888, fboWidth, fboHeight, false, true);
+        var fbo = new FrameBuffer(Pixmap.Format.RGBA8888, fboWidth, fboHeight, false);
         var viewport = new FitViewport(tvg.getWidth(), tvg.getHeight());
         viewport.update(fboWidth, fboHeight, true);
 


### PR DESCRIPTION
This pull request changes up `toTextureRegion()` a bit.

* Enables the stencil buffer on the framebuffer to improve rendering.
* Negative-size TVGs now behave correctly.
* Negative- and zero-size TVGs no longer cause it to crash.
* Handling of float to int conversion for framebuffer size has been improved.
* Added a supersampling overload to work around `FrameBuffer`'s lack of antialiasing support (it's infinitely faster than tvg-render but subject to texture size limits).
* Removed the `clear()` because new framebuffers are always empty (in my experience) and clearing them takes time.
* Made some subjective changes that you should just revert without discussion if you disagree with.

Known issues:

* `viewport.update()` ignores the width and height passed into it. This has nothing to do with me removing `viewport.apply()` - it doesn't work with that either.
* When supersampling `pirate.tvg`, his face is smoothened out nicely but the edges of his face are jaggy. Putting him on a solid background fixes this. Something is wrong with alpha. I've tried layering a semi-transparent rectangle down and that has the correct alpha, so I really don't know what is going on.

I'm unsure what the state is in tests because `Assertions.assertTrue(lock.await(5, TimeUnit.SECONDS));` and its friends fail. Hopefully all is well. It's not identical to my test code due to a difference in Java versions and I didn't figure out how to do an `mvn install` on this library's source code.

This pull request is feature creep, considering it was only supposed to be a single-line change. You may just want to copy the line I came here for, with its original name of `buffer`, into the repository for now, since it's the important fix.

https://github.com/lyze237/gdx-TinyVG/blob/7db63a4998af58c785c9653965dd3d934e830d62/src/main/java/dev/lyze/gdxtinyvg/TinyVGIO.java#L28