### PR TITLE
Added TinyVGDrawable.

### DIFF
--- a/src/main/java/dev/lyze/gdxtinyvg/scene2d/TinyVGDrawable.java
+++ b/src/main/java/dev/lyze/gdxtinyvg/scene2d/TinyVGDrawable.java
@@ -1,0 +1,107 @@
+package dev.lyze.gdxtinyvg.scene2d;
+
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.scenes.scene2d.utils.BaseDrawable;
+import com.badlogic.gdx.scenes.scene2d.utils.TransformDrawable;
+import dev.lyze.gdxtinyvg.TinyVG;
+import dev.lyze.gdxtinyvg.drawers.TinyVGShapeDrawer;
+
+/**
+ * Allows TinyVG to be implemented in Scene2D.UI Stages via the Drawable interface. The Batch used by the provided the
+ * TinyVGShapeDrawer must be the same Batch used by the Scene2D Stage.
+ */
+public class TinyVGDrawable extends BaseDrawable implements TransformDrawable {
+    public TinyVG tvg;
+    public transient TinyVGShapeDrawer shapeDrawer;
+    
+    /**
+     * A no-argument constructor necessary for serialization. {@link TinyVGDrawable#shapeDrawer} must be defined before
+     * this Drawable is drawn.
+     */
+    public TinyVGDrawable() {
+    }
+    
+    /**
+     * Constructs a TinyVGDrawable. The Batch of the provided TinyVGShapeDrawer must be the same Batch at rendering time.
+     * @param tvg
+     * @param shapeDrawer
+     */
+    public TinyVGDrawable(TinyVG tvg, TinyVGShapeDrawer shapeDrawer) {
+        this.tvg = tvg;
+        this.shapeDrawer = shapeDrawer;
+    }
+    
+    /**
+     * Creates a new TinyVGDrawable with the same sizing information and tvg values as the specified drawable.
+     *
+     * @param drawable
+     */
+    public TinyVGDrawable(TinyVGDrawable drawable) {
+        super(drawable);
+        tvg = drawable.tvg;
+        shapeDrawer = drawable.shapeDrawer;
+    }
+    
+    /**
+     * Draws the user defined TinyVG to the specified position and dimensions. May throw an
+     * {@link IllegalArgumentException} if the argument batch and shapeDrawer.batch are not the same.
+     * @param batch
+     * @param x
+     * @param y
+     * @param width
+     * @param height
+     */
+    @Override
+    public void draw(Batch batch, float x, float y, float width, float height) {
+        if (shapeDrawer == null) {
+            throw new NullPointerException("shapeDrawer must be defined before the Drawable can be drawn.");
+        }
+        if (!batch.equals(shapeDrawer.getBatch())) {
+            throw new IllegalArgumentException("Argument \"batch\" does not match \"shapeDrawer.batch\"");
+        }
+        tvg.setPosition(x, y);
+        tvg.setSize(width, height);
+        tvg.draw(shapeDrawer);
+    }
+    
+    /**
+     * Draws the user defined TinyVG to the specified transform. May throw an
+     * {@link IllegalArgumentException} if the argument batch and shapeDrawer.batch are not the same.
+     * @param batch
+     * @param x
+     * @param y
+     * @param originX
+     * @param originY
+     * @param width
+     * @param height
+     * @param scaleX
+     * @param scaleY
+     * @param rotation
+     */
+    @Override
+    public void draw(Batch batch, float x, float y, float originX, float originY, float width, float height,
+                     float scaleX, float scaleY, float rotation) {
+        tvg.setPosition(x, y);
+        tvg.setOrigin(originX, originY);
+        tvg.setSize(width, height);
+        tvg.setScale(scaleX, scaleY);
+        tvg.setRotation(rotation);
+        tvg.draw(shapeDrawer);
+    }
+    
+    public TinyVG getTvg() {
+        return tvg;
+    }
+    
+    public void setTvg(TinyVG tvg) {
+        this.tvg = tvg;
+    }
+    
+    public TinyVGShapeDrawer getShapeDrawer() {
+        return shapeDrawer;
+    }
+    
+    public void setShapeDrawer(TinyVGShapeDrawer shapeDrawer) {
+        this.shapeDrawer = shapeDrawer;
+    }
+}


### PR DESCRIPTION
Hello. I created the TinyVGDrawable class to allow easy implementation of TinyVG in Scene2D widgets. Sample use:

```java
TinyVGDrawble drawable = new TinyVGDrawable(tvg, drawer);
Image image = new Image(drawable);
```

This is most useful as a way to implement a TVG graphic as a background or title image in a menu. It is not recommended to use as a replacement for standard TextureAtlas based UI's for performance reasons. Instead, one should look into TextureRegions generated from scaled TVG's.

This class is similar to the work I've done with the ShapeDrawerDrawable. Please let me know if I need to make any modifications. Thank you.