### PR TITLE
Add default minSize to TinyVGDrawable

### DIFF
--- a/src/main/java/dev/lyze/gdxtinyvg/scene2d/TinyVGDrawable.java
+++ b/src/main/java/dev/lyze/gdxtinyvg/scene2d/TinyVGDrawable.java
@@ -33,7 +33,7 @@ public class TinyVGDrawable extends BaseDrawable implements TransformDrawable {
     public TinyVGDrawable(TinyVG tvg, TinyVGShapeDrawer shapeDrawer) {
         this.tvg = tvg;
         this.shapeDrawer = shapeDrawer;
-        setMinSize(tvg.getUnscaledWidth(), tvg.getScaledHeight());
+        setMinSize(tvg.getUnscaledWidth(), tvg.getUnscaledHeight());
     }
 
     /**
@@ -106,7 +106,7 @@ public class TinyVGDrawable extends BaseDrawable implements TransformDrawable {
 
     public void setTvg(TinyVG tvg) {
         this.tvg = tvg;
-        setMinSize(tvg.getUnscaledWidth(), tvg.getScaledHeight());
+        setMinSize(tvg.getUnscaledWidth(), tvg.getUnscaledHeight());
     }
 
     public TinyVGShapeDrawer getShapeDrawer() {

--- a/src/main/java/dev/lyze/gdxtinyvg/scene2d/TinyVGDrawable.java
+++ b/src/main/java/dev/lyze/gdxtinyvg/scene2d/TinyVGDrawable.java
@@ -33,6 +33,7 @@ public class TinyVGDrawable extends BaseDrawable implements TransformDrawable {
     public TinyVGDrawable(TinyVG tvg, TinyVGShapeDrawer shapeDrawer) {
         this.tvg = tvg;
         this.shapeDrawer = shapeDrawer;
+        setMinSize(tvg.getUnscaledWidth(), tvg.getScaledHeight());
     }
 
     /**
@@ -105,6 +106,7 @@ public class TinyVGDrawable extends BaseDrawable implements TransformDrawable {
 
     public void setTvg(TinyVG tvg) {
         this.tvg = tvg;
+        setMinSize(tvg.getUnscaledWidth(), tvg.getScaledHeight());
     }
 
     public TinyVGShapeDrawer getShapeDrawer() {


### PR DESCRIPTION
Having tested the most recent version of TinyVG, it occurred to me that TinyVGDrawable should define its own minWidth and minHeight. This should be dictated by the unscaled size of the original TVG as the scale can be arbitrarily changed by the stage. Thank you for reviewing.