### PR TITLE
Added TinyVGRegionDrawable and TinyVGRegionImage.

### DIFF
--- a/src/main/java/dev/lyze/gdxtinyvg/scene2d/TinyVGRegionDrawable.java
+++ b/src/main/java/dev/lyze/gdxtinyvg/scene2d/TinyVGRegionDrawable.java
@@ -1,0 +1,118 @@
+package dev.lyze.gdxtinyvg.scene2d;
+
+import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.scenes.scene2d.utils.BaseDrawable;
+import dev.lyze.gdxtinyvg.TinyVG;
+import dev.lyze.gdxtinyvg.TinyVGIO;
+import dev.lyze.gdxtinyvg.drawers.TinyVGShapeDrawer;
+
+/**
+ * Allows TinyVG to be implemented in Scene2D.UI Stages via the Drawable interface. The {@link TinyVG} is rendered to a
+ * {@link TextureRegion} via a {@link com.badlogic.gdx.graphics.glutils.FrameBuffer} before it is rendered to the
+ * screen. {@link TinyVGRegionDrawable#update()} must be called before the drawable is drawn to the screen. Updating by
+ * every frame is an intensive operation and not a best practice. The scale of the original TinyVG is respected and
+ * automatically sets the minWidth/minHeight of the Drawable
+ */
+public class TinyVGRegionDrawable extends BaseDrawable {
+    public TinyVG tvg;
+    public transient TinyVGShapeDrawer shapeDrawer;
+    public TextureRegion textureRegion;
+    public int superSamplingPasses;
+    
+    /**
+     * A no-argument constructor necessary for serialization. {@link TinyVGDrawable#shapeDrawer} must be defined before
+     * this Drawable is drawn.
+     */
+    public TinyVGRegionDrawable() {
+    }
+    
+    public TinyVGRegionDrawable(TinyVG tvg, TinyVGShapeDrawer shapeDrawer) {
+        this.tvg = tvg;
+        this.shapeDrawer = shapeDrawer;
+    }
+    
+    public TinyVGRegionDrawable(TinyVG tvg, TinyVGShapeDrawer shapeDrawer, int superSamplingPasses) {
+        this.tvg = tvg;
+        this.shapeDrawer = shapeDrawer;
+        this.superSamplingPasses = superSamplingPasses;
+    }
+    
+    /**
+     * Creates a new TinyVGDrawable with the same sizing information and tvg value as the specified drawable.
+     *
+     * @param drawable
+     */
+    public TinyVGRegionDrawable(TinyVGRegionDrawable drawable) {
+        super(drawable);
+        tvg = drawable.tvg;
+        shapeDrawer = drawable.shapeDrawer;
+        superSamplingPasses = drawable.superSamplingPasses;
+    }
+    
+    /**
+     * Creates a new TextureRegion based on the TinyVG specified for this drawable at the specified width and height.
+     * Converts the tvg to a supersampled texture region by drawing it onto a framebuffer multiple times. Ignores
+     * Shearing. Make sure that you're not inside a batch.begin() and framebuffer.begin() Takes scale into account. Be
+     * cautious of your device's VRAM and maximum texture size. Each pass requires twice the width and height of the
+     * last!
+     */
+    public void update(int width, int height) {
+        if (width < 1) width = 1;
+        if (height < 1) height = 1;
+        tvg.setSize(width, height);
+        setMinSize(width, height);
+        textureRegion = TinyVGIO.toTextureRegion(tvg, shapeDrawer, superSamplingPasses);
+    }
+    
+    /**
+     * Creates a new TextureRegion based on the TinyVG specified for this drawable at the scaled width and height of the
+     * original tvg. Converts the tvg to a supersampled texture region by drawing it onto a framebuffer multiple times.
+     * Ignores Shearing. Make sure that you're not inside a batch.begin() and framebuffer.begin() Takes scale into
+     * account. Be cautious of your device's VRAM and maximum texture size. Each pass requires twice the width and
+     * height of the last!
+     */
+    public void update() {
+        update(MathUtils.ceil(tvg.getScaledWidth()), MathUtils.ceil(tvg.getScaledHeight()));
+    }
+    
+    /**
+     * @param batch
+     * @param x
+     * @param y
+     * @param width
+     * @param height
+     * @throws NullPointerException
+     */
+    @Override
+    public void draw(Batch batch, float x, float y, float width, float height) {
+        if (textureRegion == null)
+            throw new NullPointerException("update() must be called before the TinyVGRegionDrawable can be drawn");
+        batch.draw(textureRegion, x, y, width, height);
+    }
+    
+    public TinyVG getTvg() {
+        return tvg;
+    }
+    
+    public void setTvg(TinyVG tvg) {
+        this.tvg = tvg;
+    }
+    
+    public TinyVGShapeDrawer getShapeDrawer() {
+        return shapeDrawer;
+    }
+    
+    public void setShapeDrawer(TinyVGShapeDrawer shapeDrawer) {
+        this.shapeDrawer = shapeDrawer;
+    }
+    
+    public int getSuperSamplingPasses() {
+        return superSamplingPasses;
+    }
+    
+    public void setSuperSamplingPasses(int superSamplingPasses) {
+        this.superSamplingPasses = superSamplingPasses;
+    }
+}

--- a/src/main/java/dev/lyze/gdxtinyvg/scene2d/TinyVGRegionImage.java
+++ b/src/main/java/dev/lyze/gdxtinyvg/scene2d/TinyVGRegionImage.java
@@ -1,0 +1,79 @@
+package dev.lyze.gdxtinyvg.scene2d;
+
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.scenes.scene2d.ui.Image;
+import com.badlogic.gdx.scenes.scene2d.ui.Widget;
+import com.badlogic.gdx.utils.Scaling;
+import dev.lyze.gdxtinyvg.TinyVG;
+import dev.lyze.gdxtinyvg.drawers.TinyVGShapeDrawer;
+
+/**
+ * Allows TinyVG to be implemented in Scene2D.UI Stages via an {@link Image} actor. The Image is backed by a {@link
+ * TinyVGRegionDrawable} that can be automatically redrawn when {@link Widget#layout()} is called. The {@link TinyVG} is
+ * rendered to a {@link TextureRegion} via a {@link com.badlogic.gdx.graphics.glutils.FrameBuffer} before it is rendered
+ * to the screen. autoRedrawing is an intensive operation and should be disabled for large drawables or when many
+ * TinyVGRegionImages are used in tandem. The scale of the original TinyVG is respected and automatically sets the
+ * minWidth/minHeight of the Image.
+ */
+public class TinyVGRegionImage extends Image {
+    public TinyVGRegionDrawable drawable;
+    public boolean autoRedrawing = true;
+    
+    public TinyVGRegionImage(TinyVG tvg, TinyVGShapeDrawer shapeDrawer, int superSamplingPasses, Scaling scaling,
+                             int align) {
+        setDrawable(new TinyVGRegionDrawable(tvg, shapeDrawer, superSamplingPasses));
+        setScaling(scaling);
+        setAlign(align);
+    }
+    
+    public TinyVGRegionImage(TinyVG tvg, TinyVGShapeDrawer shapeDrawer, int superSamplingPasses, Scaling scaling) {
+        setDrawable(new TinyVGRegionDrawable(tvg, shapeDrawer, superSamplingPasses));
+        setScaling(scaling);
+    }
+    
+    public TinyVGRegionImage(TinyVG tvg, TinyVGShapeDrawer shapeDrawer, int superSamplingPasses) {
+        setDrawable(new TinyVGRegionDrawable(tvg, shapeDrawer, superSamplingPasses));
+    }
+    
+    public TinyVGRegionImage(TinyVGRegionDrawable drawable, int superSamplingPasses, Scaling scaling, int align) {
+        setDrawable(drawable);
+        setScaling(scaling);
+        setAlign(align);
+    }
+    
+    public TinyVGRegionImage(TinyVGRegionDrawable drawable, Scaling scaling) {
+        setDrawable(drawable);
+        setScaling(scaling);
+    }
+    
+    public TinyVGRegionImage(TinyVGRegionDrawable drawable) {
+        setDrawable(drawable);
+    }
+    
+    @Override
+    public void layout() {
+        super.layout();
+        if (isAutoRedrawing() && drawable != null) drawable.update(MathUtils.ceil(getImageWidth()), MathUtils.ceil(getImageHeight()));
+    }
+    
+    /**
+     * Sets a new drawable for the image. The image's pref size is the drawable's min size. If using the image actor's
+     * size rather than the pref size, {@link #pack()} can be used to size the image to its pref size.
+     *
+     * @param drawable May be null.
+     */
+    public void setDrawable(TinyVGRegionDrawable drawable) {
+        super.setDrawable(drawable);
+        this.drawable = drawable;
+        if (drawable != null) drawable.update();
+    }
+    
+    public boolean isAutoRedrawing() {
+        return autoRedrawing;
+    }
+    
+    public void setAutoRedrawing(boolean autoRedrawing) {
+        this.autoRedrawing = autoRedrawing;
+    }
+}


### PR DESCRIPTION
Per your suggestion via Discord, I have created a version of the TinyVGDrawable that is backed by a TextureRegion instead of being rendered live every frame. This is an effective strategy so long as you don't also re-render the TextureRegion every frame as well. This is mitigated by the user through calling the update() method only when a change to scale or size is done.

Asking the user to manually update is a tedious request, so TinyVGRegionImage was created as a solution to this. It is an Image Widget that can automatically call update() on the TinyVGDrawable whenever layout() is called. This is the easiest implementation of TinyVG TextureRegions in Scene2D, but can still be taxing on hardware. For example, if a user allows the user to resize the LWJGL3 window, layout() may be called multiple times while the user drags the mouse. layout() also stalls considerably if the image is stretched to large proportions.

An alternative use of TinyVGRegionImage is to set the scale of the original TinyVG ahead of time. This automatically sets the minWidth and minHeight of the widget. In this case, you should set autoRedrawing to false. This is a good option to match the DPI of a target device without sacrificing detail or performance.