### PR TITLE
Added compositeTransform to draw()

### DIFF
--- a/src/main/java/dev/lyze/gdxtinyvg/TinyVG.java
+++ b/src/main/java/dev/lyze/gdxtinyvg/TinyVG.java
@@ -81,6 +81,7 @@ public class TinyVG {
 
     private final Matrix4 backupBatchTransform = new Matrix4();
     private final Matrix4 computedTransform = new Matrix4();
+    private final Matrix4 compositeTransform = new Matrix4();
     private final Matrix4 bufferTransform = new Matrix4();
     @Getter private final Affine2 affine = new Affine2();
 
@@ -99,8 +100,11 @@ public class TinyVG {
             updateTransformationMatrix();
             dirtyTransformationMatrix = false;
         }
+        
+        compositeTransform.set(backupBatchTransform);
+        compositeTransform.mul(computedTransform);
 
-        drawer.getBatch().setTransformMatrix(computedTransform);
+        drawer.getBatch().setTransformMatrix(compositeTransform);
 
         if (clipBasedOnTVGSize) {
             Gdx.gl.glDepthMask(true);


### PR DESCRIPTION
Some Scene2D widgets modify the transform matrix to position their children. This complicates the use of TVG as an element of user interfaces because it also uses the transform matrix to position/scale/shear/etc the drawing. By multiplying the transform of the batch by the computed transform, you will have a composited matrix that results in the correct result.