### PR TITLE
Fixed color in TinyVGDrawable

### DIFF
--- a/src/main/java/dev/lyze/gdxtinyvg/scene2d/TinyVGDrawable.java
+++ b/src/main/java/dev/lyze/gdxtinyvg/scene2d/TinyVGDrawable.java
@@ -70,7 +70,10 @@ public class TinyVGDrawable extends BaseDrawable implements TransformDrawable {
         }
         tvg.setPosition(x, y);
         tvg.setSize(width, height);
+        float previousColor = shapeDrawer.getPackedColor();
+        shapeDrawer.setColor(batch.getColor());
         tvg.draw(shapeDrawer);
+        shapeDrawer.setColor(previousColor);
     }
 
     /**
@@ -97,7 +100,10 @@ public class TinyVGDrawable extends BaseDrawable implements TransformDrawable {
         tvg.setSize(width, height);
         tvg.setScale(scaleX, scaleY);
         tvg.setRotation(rotation);
+        float previousColor = shapeDrawer.getPackedColor();
+        shapeDrawer.setColor(batch.getColor());
         tvg.draw(shapeDrawer);
+        shapeDrawer.setColor(previousColor);
     }
 
     public TinyVG getTvg() {


### PR DESCRIPTION
I realize now that TinyVGDrawable has not been setting the appropriate color when it is drawn. Scene2D modifies the Batch color, however TinyVG depends on the ShapeDrawer color to tint its drawings. I must atone for my sins. This PR should address this issue.